### PR TITLE
fixed chat for heroku

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("REDISCLOUD_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: MaDoggo_production


### PR DESCRIPTION
fixed heroku chat to be working and not bringing an error
*(still need SSL)*